### PR TITLE
Add script to fetch download count

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,12 @@ Currently available for debian based system will release for other systems later
 - From source :
 
 	Please see [Install](Install.md)
+## Downloads
+[![SVG Banners](https://svg-banners.vercel.app/api?type=typeWriter&text1=Download%20Count&width=800&height=400)](extra/download-count.md)
+
 
 ## For commands and usage follow the [docs](https://bare.surge.sh)
+
 
 
 

--- a/extra/download-count.md
+++ b/extra/download-count.md
@@ -1,0 +1,4 @@
+# Downloads
+[![SVG Banners](https://svg-banners.vercel.app/api?type=origin&text1=NPM&width=800&height=400)]()
+
+:calendar: Date: 2021-10-12, :calculator: Count: 299

--- a/extra/download-count.py
+++ b/extra/download-count.py
@@ -1,0 +1,26 @@
+from datetime import date
+
+
+import requests as rq
+import json
+
+
+launchday = '2021-09-06'
+today = date.today()
+pkg_name = "barego"
+URL = f"https://api.npmjs.org/downloads/point/{launchday}:{today}/{pkg_name}"
+
+response = rq.get(URL)
+
+if response.status_code == rq.codes.ok:
+	download_count = str(json.loads(response.text)['downloads'])
+
+
+
+f_content = f"""# Downloads\n[![SVG Banners](https://svg-banners.vercel.app/api?type=origin&text1=NPM&width=800&height=400)](https://www.npmjs.com/package/barego)
+\n:calendar: Date: {today}, :calculator: Count: {download_count}
+"""
+
+with open("extra/download-count.md", "w") as f:
+	f.write(f_content)
+	


### PR DESCRIPTION
Signed-off-by: Himanshu Pandey <hp77codeforgood@gmail.com>


I have created a simple script to fetch download count from `npm.js` and update a `.md` file along withit. couldn't find a way to automate this process or link it with some `git hooks`, if you know of something, add a hook for it. Much appreciated. Btw also let me know if we need this or not.